### PR TITLE
fix: deserialize with objectMapper instead of readEntity

### DIFF
--- a/src/main/java/com/baronswindle/MessagePackClient.java
+++ b/src/main/java/com/baronswindle/MessagePackClient.java
@@ -1,7 +1,11 @@
 package com.baronswindle;
 
+import java.io.IOException;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
 import org.msgpack.jackson.dataformat.MessagePackMapper;
 
 import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
@@ -21,12 +25,13 @@ public class MessagePackClient {
                 .register(JacksonMessagePackProvider.class);
     }
 
-    Map<String, Object> getResponse() {
-        return this.target
+    Map<String, Object> getResponse() throws IOException {
+        var response = this.target
                 .request("application/x-msgpack")
-                .get()
-                .readEntity(new GenericType<Map<String, Object>>() {
-                });
+                .get();
+        var bytes = response.readEntity(byte[].class);
+        var mapper = new ObjectMapper(new MessagePackFactory());
+        return mapper.readValue(bytes, new TypeReference<Map<String, Object>>() {});
     }
 
     @Provider


### PR DESCRIPTION
The byte content going in and out is exactly the same, it seems as though there's a discrepancy between `readEntity` and `ObjectMapper.readValue`. This was a complete accident for me, and I'm not sure that it's what you're looking for. I encountered it when I was attempting to print the byte information on both ends. Because I needed to see the bytes, I broke up the call to `readValue`. All in all, I have no clue why this works, my only guess is that there's something unexpected about the `readEntity` implementation which in this case would be Jersey.

```
[getResponse] Response Content-Length: -1
[getResponse] Response Bytes Length: 25
[getResponse] Response Bytes: 82 a4 6b 65 79 31 a6 76 61 6c 75 65 31 a4 6b 65 79 32 a6 76 61 6c 75 65 32 
[convertJsonStringToMessagePack] Length: 25
[convertJsonStringToMessagePack] Bytes: 82 a4 6b 65 79 31 a6 76 61 6c 75 65 31 a4 6b 65 79 32 a6 76 61 6c 75 65 32 
```


![image](https://github.com/baronswindle/jackson-msgpack-issue/assets/9408481/66c918da-4b2e-4119-b454-94058251f9db)

You can see the version of the code with all the logs on my `main` branch https://github.com/HeyZoos/jackson-msgpack-issue/tree/main

These messages made me think the content length needed to be explicitly set:

```
[getResponse] Response Content-Length: -1
...
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); byte offset: #25]
```
```
.withHeader(HttpHeaders.CONTENT_LENGTH, String.valueOf(bytes.length))
```

But that did not change things:

```
[convertJsonStringToMessagePack] Length: 25
[convertJsonStringToMessagePack] Bytes: 82 a4 6b 65 79 31 a6 76 61 6c 75 65 31 a4 6b 65 79 32 a6 76 61 6c 75 65 32 
Jun 19, 2024 7:23:43 PM org.glassfish.jersey.client.innate.inject.NonInjectionManager <init>
WARNING: Falling back to injection-less client.

org.opentest4j.AssertionFailedError: Unexpected exception thrown: jakarta.ws.rs.ProcessingException: Error reading entity from input stream.
````
